### PR TITLE
Fix import @cycle/fetch in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Basics:
 ```js
 import 'whatwg-fetch' // polyfill if you want to support older browsers
 import Cycle from '@cycle/core';
-import { makeFetchDriver } from 'cycle-fetch-driver';
+import { makeFetchDriver } from '@cycle/fetch';
 
 function main(responses) {
   // ...

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ function main(responses) {
 }
 
 const drivers = {
-  Fetch: makeFetchDriver()
+  HTTP: makeFetchDriver()
 }
 
 Cycle.run(main, drivers);


### PR DESCRIPTION
Just fix import string in first example.

What you think about stream names in examples: `Fetch` vs. `HTTP`? I can fix it as well.
